### PR TITLE
Added .bms extension (tectoy stuff)

### DIFF
--- a/libretro/Makefile.rules
+++ b/libretro/Makefile.rules
@@ -23,7 +23,7 @@ else ifeq ($(MACHINE), gb)
 else ifeq ($(MACHINE), nes)
 	VALID_EXTS = nes|bin|rom
 else ifeq ($(MACHINE), sms)
-	VALID_EXTS = sms|bin|rom
+	VALID_EXTS = sms|bms|bin|rom
 endif
 
 all: $(TARGET)


### PR DESCRIPTION
The .bms extension is used by TecToy in their Mega Drive 4 system, TecToy being officially licensed by SEGA. As such, we have added it to the emulator